### PR TITLE
Refactor classname in api source and README example code

### DIFF
--- a/PCPartPicker_API/pcpartpicker.py
+++ b/PCPartPicker_API/pcpartpicker.py
@@ -42,7 +42,7 @@ class productLists(object):
         """
         Returns the total number of pages for partType
         """
-        return lists._getPage(partType, 1, True)
+        return productLists._getPage(partType, 1, True)
 
     @staticmethod
     def getProductList(partType, pageNum=0):
@@ -51,13 +51,13 @@ class productLists(object):
         pages. pageNum starts at 1
         """
         if pageNum == 0:
-            start_pageNum, end_pageNum = 1, lists.totalPages(partType)
+            start_pageNum, end_pageNum = 1, productLists.totalPages(partType)
         else:
             start_pageNum, end_pageNum = pageNum, pageNum
 
         cpuList = []
         for pageNum in range(start_pageNum, end_pageNum+1):
-            soup = lists._getPage(partType, pageNum)
+            soup = productLists._getPage(partType, pageNum)
             for row in soup.find_all("tr"):
                 cpuDetails = {}
                 for count, value in enumerate(row):

--- a/README.md
+++ b/README.md
@@ -27,22 +27,22 @@ from PCPartPicker_API import pcpartpicker as pcpp
 # Print the total amount of pages for CPUs
 print("Total CPU pages:", pcpp.productLists.totalPages("cpu"))
 
-# Pull info from page 1 of CPUs
-cpu_info = pcpp.productLists.getList("cpu", 1)
+# # Pull info from page 1 of CPUs
+cpu_info = pcpp.productLists.getProductList("cpu", 1)
 
-# Print the names and prices of all the CPUs on the page
+# # Print the names and prices of all the CPUs on the page
 for cpu in cpu_info:
     print(cpu["name"], ":", cpu["price"])
 
-# Change the region to UK (the default is US)
+# # Change the region to UK (the default is US)
 pcpp.setRegion("uk")
 print("\nRegion changed to UK")
 
-# Pull info from all CPU pages (this may take a minute)
-cpu_info_uk = pcpp.productLists.getList("cpu")
+# # Pull info from all CPU pages (this may take a minute)
+cpu_info_uk = pcpp.productLists.getProductList("cpu")
 
-# Print the names and prices of all the CPUs on all pages
-# The prices will now be in GBP (£) instead of USD ($)
+# # Print the names and prices of all the CPUs on all pages
+# # The prices will now be in GBP (£) instead of USD ($)
 for cpu in cpu_info_uk:
     print(cpu["name"], ":", cpu["price"])
 ```


### PR DESCRIPTION
* Renamed variable `list` to `productsList` inside pcpartpicker.py
* Renamed method name `getList` to `getProductList` inside README.md